### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -212,4 +212,4 @@ VincentKo (@forrany) - [GitHub](https://github.com/forrany)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=forrany/Awesome-Ollama-Server&type=Date)](https://star-history.com/#forrany/Awesome-Ollama-Server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=forrany/Awesome-Ollama-Server&type=Date)](https://star-history.dera.page/#forrany/Awesome-Ollama-Server&Date)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ VincentKo (@forrany) - [GitHub](https://github.com/forrany)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=forrany/Awesome-Ollama-Server&type=Date)](https://star-history.com/#forrany/Awesome-Ollama-Server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=forrany/Awesome-Ollama-Server&type=Date)](https://star-history.dera.page/#forrany/Awesome-Ollama-Server&Date)
 
 ## Docker 部署
 


### PR DESCRIPTION
The star history chart shown in the README is broken: the API it depends on is no longer working due to GitHub stargazer API restrictions. This change points the chart to a working source so it displays correctly again. Applied to both README.md and README.EN.md.